### PR TITLE
Fix bauds+

### DIFF
--- a/buds_battery.py
+++ b/buds_battery.py
@@ -27,7 +27,7 @@ def print_result(string, timestamp):
 
 
 def parse_message(data, islegacy, timestamp):
-    if data[0] != (0xFE if islegacy else 0xFD ):
+    if data[0] != (0xFE if islegacy else 0xFD):
         print("Invalid SOM")
         exit(2)
     if data[3] == 97:
@@ -92,8 +92,9 @@ def id_to_placement(id):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Read battery values of the Samsung Galaxy Buds, Buds+, Buds Live or Buds Pro'
-                                                 '[Left, Right, Case (Buds+ or later)]')
+    parser = argparse.ArgumentParser(
+        description='Read battery values of the Samsung Galaxy Buds, Buds+, Buds Live or Buds Pro'
+                    '[Left, Right, Case (Buds+ or later)]')
     parser.add_argument('mac', metavar='mac-address', type=str, nargs=1,
                         help='MAC-Address of your Buds')
     parser.add_argument('-m', '--monitor', action='store_true', help="Notify on change")

--- a/buds_battery.py
+++ b/buds_battery.py
@@ -117,7 +117,7 @@ def main():
 
     port = host = None
     for match in service_matches:
-        if match["name"] == b"GEARMANAGER":
+        if match["name"] in (b"GEARMANAGER", "GEARMANAGER"):
             port = match["port"]
             host = match["host"]
             break


### PR DESCRIPTION
fixes #7

`match["name"]` in my system is `"GEARMANAGER"` rather than `b"GEARMANAGER"`

also my pybluez is version 0.23 and I'm on Arch Linux, maybe something is changed upstream?