### PR TITLE
Handle different service match names

### DIFF
--- a/buds_battery.py
+++ b/buds_battery.py
@@ -123,7 +123,7 @@ def main():
         else:
             target_name = b"GEARMANAGER"
 
-        if match["name"] == target_name:
+        if target_name in match["name"]:
             port = match["port"]
             host = match["host"]
             break


### PR DESCRIPTION
Fixes #11 (and maybe #9, not much info was provided, but they had the same error message).